### PR TITLE
Revert "feat: configurable security groups for ECS instances"

### DIFF
--- a/00-variables.tf
+++ b/00-variables.tf
@@ -50,12 +50,6 @@ variable "ecs_cluster_name" {
   default = "ecs_cluster"
 }
 
-variable "instance_security_groups" {
-  description = "Additional security groups for ECS instances"
-  type = "list"
-  default = []
-}
-
 variable "tags" {
   description = "Additional tags to add to resources"
   type = "map"

--- a/06-nodes.tf
+++ b/06-nodes.tf
@@ -34,16 +34,12 @@ resource "aws_launch_configuration" "ecs_cluster_node" {
     create_before_destroy = true
   }
 
-  security_groups = ["${concat(
-    list(
-      aws_security_group.intra_node_communication.id,
-      aws_security_group.public_ingress.id,
-      aws_security_group.public_egress.id,
-      aws_security_group.ssh_access.id
-    ),
-    var.instance_security_groups
-  )}"]
-
+  security_groups = [
+    "${aws_security_group.intra_node_communication.id}",
+    "${aws_security_group.public_ingress.id}",
+    "${aws_security_group.public_egress.id}",
+    "${aws_security_group.ssh_access.id}",
+  ]
   associate_public_ip_address = "true"
   user_data                   = "${data.template_file.node_userdata.rendered}"
   key_name = "${aws_key_pair.keypair.key_name}"


### PR DESCRIPTION
At the moment, this will not work as we would need the VPC ID to build security groups. So this'll have to be re-though